### PR TITLE
AL-37: Remove Username header requirement from GET /alert endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/config/AlertRequestContextConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/config/AlertRequestContextConfiguration.kt
@@ -35,17 +35,19 @@ class AlertRequestContextInterceptor(
   private val userService: UserService,
 ) : HandlerInterceptor {
   override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
-    val source = request.getSource()
-    val userDetails = request.getUserDetails(source)
+    if (arrayOf("POST", "PUT", "DELETE").contains(request.method)) {
+      val source = request.getSource()
+      val userDetails = request.getUserDetails(source)
 
-    request.setAttribute(
-      AlertRequestContext::class.simpleName,
-      AlertRequestContext(
-        source = source,
-        username = userDetails.username,
-        userDisplayName = userDetails.name,
-      ),
-    )
+      request.setAttribute(
+        AlertRequestContext::class.simpleName,
+        AlertRequestContext(
+          source = source,
+          username = userDetails.username,
+          userDisplayName = userDetails.name,
+        ),
+      )
+    }
 
     return true
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/AlertsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/AlertsController.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.util.UUID
 
 @RestController
-@UsernameHeader
 @RequestMapping("/alerts", produces = [MediaType.APPLICATION_JSON_VALUE])
 class AlertsController(
   private val alertService: AlertService,
@@ -70,6 +69,7 @@ class AlertsController(
     ],
   )
   @PreAuthorize("hasAnyRole('$ROLE_ALERTS_WRITER', '$ROLE_ALERTS_ADMIN', '$UPDATE_ALERT', '$ROLE_NOMIS_ALERTS')")
+  @UsernameHeader
   @SourceHeader
   fun createAlert(
     @Valid
@@ -152,6 +152,7 @@ class AlertsController(
     ],
   )
   @PreAuthorize("hasAnyRole('$ROLE_ALERTS_WRITER', '$ROLE_ALERTS_ADMIN', '$UPDATE_ALERT', '$ROLE_NOMIS_ALERTS')")
+  @UsernameHeader
   @SourceHeader
   fun updateAlert(
     @PathVariable
@@ -202,6 +203,7 @@ class AlertsController(
     ],
   )
   @PreAuthorize("hasAnyRole('$ROLE_ALERTS_WRITER', '$ROLE_ALERTS_ADMIN', '$UPDATE_ALERT', '$ROLE_NOMIS_ALERTS')")
+  @UsernameHeader
   @SourceHeader
   fun deleteAlert(
     @PathVariable

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/config/AlertRequestContextConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/config/AlertRequestContextConfigurationTest.kt
@@ -39,6 +39,7 @@ class AlertRequestContextConfigurationTest {
 
   @BeforeEach
   fun beforeEach() {
+    req.method = "POST"
     SecurityContextHolder.clearContext()
     whenever(userService.getUserDetails(TEST_USER)).thenReturn(userDetailsDto())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/RetrieveAlertIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/RetrieveAlertIntTest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.IntegrationTestBa
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.wiremock.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.wiremock.TEST_USER
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.wiremock.TEST_USER_NAME
-import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.wiremock.USER_NOT_FOUND
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.Alert
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.request.CreateAlert
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.repository.AlertCodeRepository
@@ -50,7 +49,6 @@ class RetrieveAlertIntTest : IntegrationTestBase() {
     webTestClient.get()
       .uri("/alerts/$uuid")
       .headers(setAuthorisation())
-      .headers(setAlertRequestContext())
       .exchange()
       .expectStatus().isForbidden
   }
@@ -60,70 +58,8 @@ class RetrieveAlertIntTest : IntegrationTestBase() {
     webTestClient.get()
       .uri("/alerts/$uuid")
       .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_WRITER)))
-      .headers(setAlertRequestContext())
       .exchange()
       .expectStatus().isForbidden
-  }
-
-  @Test
-  fun `400 bad request - invalid source`() {
-    val response = webTestClient.get()
-      .uri("/alerts/$uuid")
-      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_READER)))
-      .headers { it.set(SOURCE, "INVALID") }
-      .exchange()
-      .expectStatus().isBadRequest
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody
-
-    with(response!!) {
-      assertThat(status).isEqualTo(400)
-      assertThat(errorCode).isNull()
-      assertThat(userMessage).isEqualTo("Validation failure: No enum constant uk.gov.justice.digital.hmpps.hmppsalertsapi.enumeration.Source.INVALID")
-      assertThat(developerMessage).isEqualTo("No enum constant uk.gov.justice.digital.hmpps.hmppsalertsapi.enumeration.Source.INVALID")
-      assertThat(moreInfo).isNull()
-    }
-  }
-
-  @Test
-  fun `400 bad request - username not supplied`() {
-    val response = webTestClient.get()
-      .uri("/alerts/$uuid")
-      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_READER)))
-      .exchange()
-      .expectStatus().isBadRequest
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody
-
-    with(response!!) {
-      assertThat(status).isEqualTo(400)
-      assertThat(errorCode).isNull()
-      assertThat(userMessage)
-        .isEqualTo("Validation failure: Could not find non empty username from user_name or username token claims or Username header")
-      assertThat(developerMessage)
-        .isEqualTo("Could not find non empty username from user_name or username token claims or Username header")
-      assertThat(moreInfo).isNull()
-    }
-  }
-
-  @Test
-  fun `400 bad request - username not found`() {
-    val response = webTestClient.get()
-      .uri("/alerts/$uuid")
-      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_READER)))
-      .headers(setAlertRequestContext(username = USER_NOT_FOUND))
-      .exchange()
-      .expectStatus().isBadRequest
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody
-
-    with(response!!) {
-      assertThat(status).isEqualTo(400)
-      assertThat(errorCode).isNull()
-      assertThat(userMessage).isEqualTo("Validation failure: User details for supplied username not found")
-      assertThat(developerMessage).isEqualTo("User details for supplied username not found")
-      assertThat(moreInfo).isNull()
-    }
   }
 
   @Test
@@ -131,7 +67,6 @@ class RetrieveAlertIntTest : IntegrationTestBase() {
     val response = webTestClient.get()
       .uri("/alerts/$uuid")
       .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_READER)))
-      .headers(setAlertRequestContext())
       .exchange()
       .expectStatus().isNotFound
       .expectBody(ErrorResponse::class.java)
@@ -153,7 +88,6 @@ class RetrieveAlertIntTest : IntegrationTestBase() {
     val response = webTestClient.get()
       .uri("/alerts/${alert.alertUuid}")
       .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_READER)))
-      .headers(setAlertRequestContext())
       .exchange()
       .expectStatus().isOk
       .expectBody(Alert::class.java)


### PR DESCRIPTION
Not required for audit and affecting sync