### PR TITLE
AL-116 Add Reactivate Alert Type endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/AlertType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/AlertType.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.Table
 import org.springframework.data.domain.AbstractAggregateRoot
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.event.AlertTypeCreatedEvent
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.event.AlertTypeDeactivatedEvent
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.event.AlertTypeReactivatedEvent
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.event.AlertTypeUpdatedEvent
 import java.time.LocalDateTime
 
@@ -49,6 +50,12 @@ data class AlertType(
   fun deactivate(): AlertType = this.also {
     registerEvent(
       AlertTypeDeactivatedEvent(code, deactivatedAt!!),
+    )
+  }
+
+  fun reactivate(requestAt: LocalDateTime): AlertType = this.also {
+    registerEvent(
+      AlertTypeReactivatedEvent(code, requestAt),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/event/AlertEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/event/AlertEvent.kt
@@ -184,6 +184,15 @@ data class AlertTypeDeactivatedEvent(
   override fun toDomainEvent(baseUrl: String): AlertDomainEvent =
     toDomainEvent(DomainEventType.ALERT_TYPE_DEACTIVATED, baseUrl)
 }
+
+data class AlertTypeReactivatedEvent(
+  override val alertCode: String,
+  override val occurredAt: LocalDateTime,
+) : AlertTypeEvent() {
+  override fun toDomainEvent(baseUrl: String): AlertDomainEvent =
+    toDomainEvent(DomainEventType.ALERT_TYPE_REACTIVATED, baseUrl)
+}
+
 data class AlertTypeUpdatedEvent(
   override val alertCode: String,
   override val occurredAt: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/enumeration/DomainEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/enumeration/DomainEventType.kt
@@ -12,5 +12,6 @@ enum class DomainEventType(
   ALERT_CODE_UPDATED("prisoner-alerts.alert-code-updated", "An alert code has been updated in the alerts reference data service"),
   ALERT_TYPE_CREATED("prisoner-alerts.alert-type-created", "An alert type has been created in the alerts reference data service"),
   ALERT_TYPE_DEACTIVATED("prisoner-alerts.alert-type-deactivated", "An alert type has been deactivated in the alerts reference data service"),
+  ALERT_TYPE_REACTIVATED("prisoner-alerts.alert-type-reactivated", "An alert type has been reactivated in the alerts reference data service"),
   ALERT_TYPE_UPDATED("prisoner-alerts.alert-type-updated", "An alert type has been updated in the alerts reference data service"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/AlertTypesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/AlertTypesController.kt
@@ -175,6 +175,43 @@ class AlertTypesController(
 
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasAnyRole('$ROLE_ALERTS_ADMIN')")
+  @PatchMapping("/{alertType}/reactivate")
+  @Operation(
+    summary = "Reactivate an alert type",
+    description = "Reactivate an alert type, typically from the Alerts UI",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Alert type reactivated",
+        content = [Content(schema = Schema(implementation = AlertType::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Not found, the alert type was is not found",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @UsernameHeader
+  fun reactivateAlertType(
+    @PathVariable alertType: String,
+    httpRequest: HttpServletRequest,
+  ) = alertTypeService.reactivateAlertType(alertType, httpRequest.alertRequestContext())
+
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasAnyRole('$ROLE_ALERTS_ADMIN')")
   @PatchMapping("/{alertType}")
   @Operation(
     summary = "Update alert type",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertTypeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertTypeService.kt
@@ -50,6 +50,20 @@ class AlertTypeService(
     }
 
   @Transactional
+  fun reactivateAlertType(alertType: String, alertRequestContext: AlertRequestContext) =
+    alertType.let {
+      it.checkAlertTypeExists()
+      with(alertTypeRepository.findByCode(it)!!) {
+        if (deactivatedAt != null) {
+          deactivatedAt = null
+          deactivatedBy = null
+          reactivate(alertRequestContext.requestAt)
+        }
+        alertTypeRepository.saveAndFlush(this).toAlertTypeModel(false)
+      }
+    }
+
+  @Transactional
   fun updateAlertType(
     alertType: String,
     updateAlertTypeRequest: UpdateAlertTypeRequest,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/ReactivateAlertTypeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/ReactivateAlertTypeIntTest.kt
@@ -1,0 +1,197 @@
+package uk.gov.justice.digital.hmpps.hmppsalertsapi.resource
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.event.AlertDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.event.ReferenceDataAdditionalInformation
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.enumeration.DomainEventType
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.enumeration.Source
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.wiremock.TEST_USER
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.integration.wiremock.USER_NOT_FOUND
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.AlertType
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.request.CreateAlertTypeRequest
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.repository.AlertTypeRepository
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class ReactivateAlertTypeIntTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var alertTypeRepository: AlertTypeRepository
+
+  @Test
+  fun `401 unauthorised`() {
+    webTestClient.patch()
+      .uri("/alert-types/VI/reactivate")
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  fun `403 forbidden - no roles`() {
+    webTestClient.patch()
+      .uri("/alert-types/VI/reactivate")
+      .headers(setAuthorisation())
+      .headers(setAlertRequestContext())
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `403 forbidden - alerts reader`() {
+    webTestClient.patch()
+      .uri("/alert-types/VI/reactivate")
+      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_READER)))
+      .headers(setAlertRequestContext())
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `400 bad request - username not supplied`() {
+    val response = webTestClient.patch()
+      .uri("/alert-types/VI/reactivate")
+      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_ADMIN)))
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage)
+        .isEqualTo("Validation failure: Could not find non empty username from user_name or username token claims or Username header")
+      assertThat(developerMessage)
+        .isEqualTo("Could not find non empty username from user_name or username token claims or Username header")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `400 bad request - username not found`() {
+    val response = webTestClient.patch()
+      .uri("/alert-types/VI/reactivate")
+      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_ADMIN)))
+      .headers(setAlertRequestContext(username = USER_NOT_FOUND))
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Validation failure: User details for supplied username not found")
+      assertThat(developerMessage).isEqualTo("User details for supplied username not found")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `404 alert type not found`() {
+    val response = webTestClient.patch()
+      .uri("/alert-types/ALK/reactivate")
+      .headers(setAuthorisation(roles = listOf(ROLE_ALERTS_ADMIN)))
+      .headers(setAlertRequestContext())
+      .exchange()
+      .expectStatus().isNotFound
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(404)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Not found: Alert type with code ALK could not be found")
+      assertThat(developerMessage)
+        .isEqualTo("Alert type with code ALK could not be found")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `should mark alert type as active`() {
+    val alertType = createAlertType()
+    alertTypeRepository.findByCode(alertType.code)!!.apply {
+      deactivatedAt = LocalDateTime.of(2010, 3, 7, 16, 27, 58)
+      deactivatedBy = "MODIFIED_BY"
+      alertTypeRepository.save(this)
+    }
+
+    val response = webTestClient.reactivateAlertType(alertCode = alertType.code)
+    assertThat(response.isActive).isEqualTo(true)
+
+    alertTypeRepository.findByCode(alertType.code)!!.apply {
+      assertThat(deactivatedAt).isNull()
+      assertThat(deactivatedBy).isNull()
+    }
+  }
+
+  @Test
+  fun `should publish alert types reactivated event with NOMIS source`() {
+    val alertType = createAlertType()
+    alertTypeRepository.findByCode(alertType.code)!!.apply {
+      deactivatedAt = LocalDateTime.of(2010, 3, 7, 16, 27, 58)
+      deactivatedBy = "MODIFIED_BY"
+      alertTypeRepository.save(this)
+    }
+
+    webTestClient.reactivateAlertType(alertType.code)
+
+    await untilCallTo { hmppsEventsQueue.countAllMessagesOnQueue() } matches { it == 2 }
+    val createAlertEvent = hmppsEventsQueue.receiveAlertDomainEventOnQueue()
+    val reactivateAlertEvent = hmppsEventsQueue.receiveAlertDomainEventOnQueue()
+
+    assertThat(createAlertEvent.eventType).isEqualTo(DomainEventType.ALERT_TYPE_CREATED.eventType)
+    assertThat(createAlertEvent.additionalInformation.identifier()).isEqualTo(reactivateAlertEvent.additionalInformation.identifier())
+    assertThat(reactivateAlertEvent).usingRecursiveComparison().isEqualTo(
+      AlertDomainEvent(
+        DomainEventType.ALERT_TYPE_REACTIVATED.eventType,
+        ReferenceDataAdditionalInformation(
+          "http://localhost:8080/alert-types/${alertType.code}",
+          alertType.code,
+          Source.DPS,
+        ),
+        1,
+        DomainEventType.ALERT_TYPE_REACTIVATED.description,
+        reactivateAlertEvent.occurredAt,
+      ),
+    )
+    assertThat(reactivateAlertEvent.occurredAt).isCloseTo(LocalDateTime.now(), Assertions.within(3, ChronoUnit.SECONDS))
+  }
+
+  private fun createAlertTypeRequest(code: String = "ABC") =
+    CreateAlertTypeRequest(code, "description")
+
+  private fun createAlertType(request: CreateAlertTypeRequest = createAlertTypeRequest()): AlertType {
+    return webTestClient.post()
+      .uri("/alert-types")
+      .bodyValue(request)
+      .headers(setAuthorisation(user = TEST_USER, roles = listOf(ROLE_ALERTS_ADMIN), isUserToken = true))
+      .exchange()
+      .expectStatus().isCreated
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(AlertType::class.java)
+      .returnResult().responseBody!!
+  }
+
+  private fun WebTestClient.reactivateAlertType(
+    alertCode: String,
+  ): AlertType =
+    patch()
+      .uri("/alert-types/$alertCode/reactivate")
+      .headers(setAuthorisation(user = TEST_USER, roles = listOf(ROLE_ALERTS_ADMIN), isUserToken = true))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(AlertType::class.java)
+      .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertTypeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertTypeServiceTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.request.CreateAlertType
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.request.UpdateAlertTypeRequest
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.repository.AlertTypeRepository
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.utils.alertTypeVulnerability
+import uk.gov.justice.digital.hmpps.hmppsalertsapi.utils.alertTypeVulnerabilityDeactivated
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
@@ -98,6 +99,21 @@ class AlertTypeServiceTest {
     assertThat(value).isNotNull
     assertThat(value.deactivatedBy).isEqualTo("USER")
     assertThat(value.deactivatedAt).isCloseTo(LocalDateTime.now(), Assertions.within(3, ChronoUnit.SECONDS))
+  }
+
+  @Test
+  fun `reactivate an alert type`() {
+    whenever(alertTypeRepository.findByCode(any())).thenReturn(alertTypeVulnerabilityDeactivated())
+    whenever(alertTypeRepository.saveAndFlush(any())).thenReturn(alertType())
+    service.reactivateAlertType(
+      "VI",
+      AlertRequestContext(username = "USER", userDisplayName = "USER", activeCaseLoadId = null),
+    )
+    verify(alertTypeRepository).saveAndFlush(entityCaptor.capture())
+    val value = entityCaptor.firstValue
+    assertThat(value).isNotNull
+    assertThat(value.deactivatedBy).isNull();
+    assertThat(value.deactivatedAt).isNull();
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertTypeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertTypeServiceTest.kt
@@ -112,8 +112,8 @@ class AlertTypeServiceTest {
     verify(alertTypeRepository).saveAndFlush(entityCaptor.capture())
     val value = entityCaptor.firstValue
     assertThat(value).isNotNull
-    assertThat(value.deactivatedBy).isNull();
-    assertThat(value.deactivatedAt).isNull();
+    assertThat(value.deactivatedBy).isNull()
+    assertThat(value.deactivatedAt).isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/utils/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/utils/TestConstants.kt
@@ -52,6 +52,21 @@ fun alertTypeVulnerability() =
     modifiedBy = "MODIFIED_BY"
   }
 
+fun alertTypeVulnerabilityDeactivated() =
+  AlertType(
+    18,
+    "V",
+    "Vulnerability",
+    6,
+    LocalDateTime.of(2006, 6, 28, 16, 19, 42),
+    "CREATED_BY",
+  ).apply {
+    modifiedAt = LocalDateTime.of(2010, 3, 7, 16, 27, 58)
+    modifiedBy = "MODIFIED_BY"
+    deactivatedAt = LocalDateTime.of(2010, 3, 7, 16, 27, 58)
+    deactivatedBy = "MODIFIED_BY"
+  }
+
 fun alertTypeCovidUnitManagement() =
   AlertType(
     17,


### PR DESCRIPTION
`PATCH /alert-types/{alertType}/reactivate` removes deactivatedBy and deactivatedAt values and publish reactivation events to NOMIS.