### PR TITLE
MIAD-70 increase to paranoia level 2

### DIFF
--- a/helm_deploy/hmpps-alerts-api/values.yaml
+++ b/helm_deploy/hmpps-alerts-api/values.yaml
@@ -29,6 +29,7 @@ generic-service:
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   # Used to access resources like S3 buckets, SQS queues and SNS topics
   serviceAccountName: hmpps-alerts-api


### PR DESCRIPTION
The default for this is paranoia level 1, but the ticket specifically asks for level 2. This will increase the chances/frequency of false positives, however, still in detect only mode so shouldn't be any risk.