### PR TITLE
MIAD-301: Disable slack notifications for prod deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,6 @@ workflows:
           jira_env_type: production
           pipeline_id: <<pipeline.id>>
           pipeline_number: <<pipeline.number>>
-          slack_notification: true
-          slack_channel_name: move-and-improve-alerts
           context:
             - hmpps-common-vars
             - hmpps-alerts-api-prod


### PR DESCRIPTION
Update config.yml to disable Slack notifications for production deployments