### PR TITLE
CDPS-2009: Update SchemaSpy report generation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       - "*"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "localstack/localstack"
+        versions:
+          - ">4"
   - package-ecosystem: "github-actions"
     multi-ecosystem-group: "infrastructure"
     directory: "/"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,11 +18,11 @@ on:
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
   packages: write
+  pages: write
   id-token: write
   attestations: write
-  pages: write
 
 concurrency:
   # Only cancel in progress when on a branch - use SHA on main to ensure uniqueness.
@@ -71,7 +71,6 @@ jobs:
       database_name: 'alerts'
       database_user: 'alerts'
       database_password: 'alerts'
-      database_schema: 'public'
     secrets: inherit
   build:
     name: Build docker image from hmpps-github-actions

--- a/.github/workflows/schema-spy.yml
+++ b/.github/workflows/schema-spy.yml
@@ -12,13 +12,13 @@ on:
         type: string
         default: '-Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
       schemaspy_version:
-        description: Schema Spy version
+        description: SchemaSpy version
         type: string
         default: '7.0.2'
       postgres_driver_version:
         description: Postgres version
         type: string
-        default: '42.7.8'
+        default: '42.7.13'
       exclude:
         description: Regex of tables to be excluded
         type: string
@@ -46,24 +46,21 @@ on:
       database_schema:
         description: Database schema name
         type: string
-        required: true
-
-permissions:
-  contents: write
+        default: public
 
 jobs:
   schema-spy:
-    name: Schema Spy report generation
+    name: Generate SchemaSpy report
     runs-on: ubuntu-latest
-    timeout-minutes: 240
     permissions:
       contents: read
       pages: write
       id-token: write
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: refresh cache
+      - name: Refresh cache
         id: initial-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
@@ -83,15 +80,15 @@ jobs:
             *.gradle*
             **/gradle-wrapper.properties
 
-      - name: Initialise database and generate Schema Spy report
+      - name: Initialise database and generate SchemaSpy report
         shell: bash
         run: |
-          docker compose -f ${{ inputs.docker_compose_file }} up -d 
+          docker compose -f ${{ inputs.docker_compose_file }} up -d
           curl -L https://github.com/schemaspy/schemaspy/releases/download/v${{ inputs.schemaspy_version }}/schemaspy-app.jar --output /tmp/schemaspy.jar
           curl -L https://jdbc.postgresql.org/download/postgresql-${{ inputs.postgres_driver_version }}.jar --output /tmp/postgres-driver.jar
           export JAVA_OPTS="${{ inputs.java_options }}"
           ${{ inputs.init_db_cli }}
-          java -jar /tmp/schemaspy.jar -t pgsql -dp /tmp/postgres-driver.jar -db ${{ inputs.database_name }} -host localhost -port 5432 -s ${{ inputs.database_schema }} -vizjs -u ${{ inputs.database_user }} -p ${{ inputs.database_password }} -I ${{ inputs.exclude }} -o /tmp/schema-spy-report
+          java -jar /tmp/schemaspy.jar -t pgsql -dp /tmp/postgres-driver.jar -db ${{ inputs.database_name }} -host localhost -port 5432 -s ${{ inputs.database_schema }} -vizjs -u ${{ inputs.database_user }} -p ${{ inputs.database_password }} -I ${{ inputs.exclude }} -norows -o /tmp/schema-spy-report
 
       - name: Setup GitHub Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -107,4 +104,4 @@ jobs:
       - name: Link workflow summary to report
         shell: bash
         run: |
-          echo '[SchemaSpy report](https://ministryofjustice.github.io/hmpps-alerts-api/)' >> $GITHUB_STEP_SUMMARY
+          echo '[SchemaSpy report]('https://$GITHUB_REPOSITORY_OWNER.github.io/$(basename $GITHUB_REPOSITORY)'/)' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![codecov](https://codecov.io/github/ministryofjustice/hmpps-alerts-api/branch/main/graph/badge.svg)](https://codecov.io/github/ministryofjustice/hmpps-alerts-api)
 [![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://alerts-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html)
 [![Event docs](https://img.shields.io/badge/Event_docs-view-85EA2D.svg)](https://studio.asyncapi.com/?readOnly&url=https://raw.githubusercontent.com/ministryofjustice/hmpps-alerts-api/main/async-api.yml)
-
-Datebase Schema diagram: https://ministryofjustice.github.io/hmpps-alerts-api/
+[![Database schema](https://img.shields.io/badge/Database_schema-view-85EA2D.svg)](https://ministryofjustice.github.io/hmpps-alerts-api/)
 
 ## Architectural Decision Records
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_USER=alerts
 
   localstack:
-    image: localstack/localstack:2026.6.2
+    image: localstack/localstack:4
     networks:
       - hmpps
     container_name: localstack


### PR DESCRIPTION
- normalise SchemaSpy report generation config between CDPS api repositories
- pin localstack image tag to 4 since newer versions require a licence