### PR TITLE
CDPS-2041 Update webClient configuration to use hmpps-kotlin-lib template

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
-  kotlin("jvm") version "2.4.0"
-  kotlin("plugin.spring") version "2.4.0"
-  kotlin("plugin.jpa") version "2.4.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "11.0.1"
+  kotlin("jvm") version "2.4.10"
+  kotlin("plugin.spring") version "2.4.10"
+  kotlin("plugin.jpa") version "2.4.10"
   jacoco
 }
 
@@ -21,8 +21,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-flyway")
   implementation("org.springframework.boot:spring-boot-starter-restclient")
   implementation("org.springframework.boot:spring-boot-starter-webclient")
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")
-  implementation("io.sentry:sentry-spring-boot-4:8.48.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:3.0.0")
+  implementation("io.sentry:sentry-spring-boot-4:8.49.0")
   implementation("com.fasterxml.uuid:java-uuid-generator:5.2.0")
 
   // Database dependencies

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/config/WebClientConfiguration.kt
@@ -1,18 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsalertsapi.config
 
-import io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS
-import io.netty.channel.ChannelOption.SO_KEEPALIVE
-import io.netty.channel.epoll.EpollChannelOption
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClient.Builder
-import reactor.netty.http.client.HttpClient
-import reactor.netty.http.client.HttpClient.create
+import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
 
@@ -31,34 +25,11 @@ class WebClientConfiguration(
   fun manageUsersHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(manageUsersBaseUri, healthTimeout)
 
   @Bean
-  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder) = getOAuthWebClient(authorizedClientManager, builder, manageUsersBaseUri)
+  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder) = builder.authorisedWebClient(authorizedClientManager, "default", manageUsersBaseUri, timeout)
 
   @Bean
   fun prisonerSearchHealthWebClient(builder: Builder): WebClient = builder.healthWebClient(prisonerSearchBaseUri, healthTimeout)
 
   @Bean
-  fun prisonerSearchWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder) = getOAuthWebClient(authorizedClientManager, builder, prisonerSearchBaseUri)
-
-  private fun getOAuthWebClient(
-    authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: Builder,
-    rootUri: String,
-  ): WebClient {
-    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
-    oauth2Client.setDefaultClientRegistrationId("default")
-    return builder.baseUrl(rootUri)
-      .clientConnector(clientConnector())
-      .apply(oauth2Client.oauth2Configuration())
-      .build()
-  }
-
-  private fun clientConnector(consumer: ((HttpClient) -> Unit)? = null): ReactorClientHttpConnector {
-    val client = create().responseTimeout(timeout)
-      .option(CONNECT_TIMEOUT_MILLIS, 1000)
-      .option(SO_KEEPALIVE, true)
-      // this will show a warning on apple (arm) architecture but will work on linux x86 container
-      .option(EpollChannelOption.TCP_KEEPINTVL, 60)
-    consumer?.also { it.invoke(client) }
-    return ReactorClientHttpConnector(client)
-  }
+  fun prisonerSearchWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: Builder) = builder.authorisedWebClient(authorizedClientManager, "default", prisonerSearchBaseUri, timeout)
 }


### PR DESCRIPTION
This updates the repository to sit with the current kotlin template, which pre-rolls `WebClient` configuration for us rather than us having to hand-roll it here. This means upgrading `hmpps-gradle-spring-boot` to `11.0.0`. The resulting breaking change due to Spring 4.1.0 in `hmpps-kotlin-lib` as documented [here](https://github.com/ministryofjustice/hmpps-gradle-spring-boot/blob/main/release-notes/11.x.md#upgrade-to-spring-boot-410) is fixed through us not hand-rolling the implementation any more, and is more elegant than implementing `.filter(ServletRequestResponseNonNullFilterFunction())` before calling out to OAuth2 filters.