### PR TITLE
CDPS-2062 Remove redundant final keywords causing warnings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/Alert.kt
@@ -118,7 +118,7 @@ class Alert(
 
   fun lastModifiedAuditEvent() = auditEvents().firstOrNull { it.action == AuditEventAction.UPDATED }
 
-  final var deletedAt: LocalDateTime? = null
+  var deletedAt: LocalDateTime? = null
     private set
 
   fun resync(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/Alert.kt
@@ -119,7 +119,7 @@ class Alert(
   fun lastModifiedAuditEvent() = auditEvents().firstOrNull { it.action == AuditEventAction.UPDATED }
 
   var deletedAt: LocalDateTime? = null
-    private set
+    internal set
 
   fun resync(
     createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/PersonSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/PersonSummary.kt
@@ -20,19 +20,19 @@ class PersonSummary(
   cellLocation: String?,
   supportingPrisonCode: String?,
 ) {
-  final var firstName: String = firstName
+  var firstName: String = firstName
     private set
-  final var lastName: String = lastName
+  var lastName: String = lastName
     private set
-  final var status: String = status
+  var status: String = status
     private set
-  final var restrictedPatient: Boolean = restrictedPatient
+  var restrictedPatient: Boolean = restrictedPatient
     private set
-  final var prisonCode: String? = prisonCode
+  var prisonCode: String? = prisonCode
     private set
-  final var cellLocation: String? = cellLocation
+  var cellLocation: String? = cellLocation
     private set
-  final var supportingPrisonCode: String? = supportingPrisonCode
+  var supportingPrisonCode: String? = supportingPrisonCode
     private set
 
   @Version

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/PersonSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/entity/PersonSummary.kt
@@ -12,29 +12,14 @@ import uk.gov.justice.digital.hmpps.hmppsalertsapi.client.prisonersearch.dto.Pri
 class PersonSummary(
   @Id
   val prisonNumber: String,
-  firstName: String,
-  lastName: String,
-  status: String,
-  restrictedPatient: Boolean,
-  prisonCode: String?,
-  cellLocation: String?,
-  supportingPrisonCode: String?,
+  var firstName: String,
+  var lastName: String,
+  var status: String,
+  var restrictedPatient: Boolean,
+  var prisonCode: String?,
+  var cellLocation: String?,
+  var supportingPrisonCode: String?,
 ) {
-  var firstName: String = firstName
-    private set
-  var lastName: String = lastName
-    private set
-  var status: String = status
-    private set
-  var restrictedPatient: Boolean = restrictedPatient
-    private set
-  var prisonCode: String? = prisonCode
-    private set
-  var cellLocation: String? = cellLocation
-    private set
-  var supportingPrisonCode: String? = supportingPrisonCode
-    private set
-
   @Version
   val version: Int? = null
 


### PR DESCRIPTION
We were getting some warnings like this:

```
org.hibernate.HibernateException: Getter methods of lazy classes cannot be final:
uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.Alert#getDeletedAt
```

It seems explicitly defining some variable fields as final interferes with hibernate's ability to use lazy versions of the class (details not super important).

Two main changes:

- `PersonSummary.kt`, `final var` fields are now simply `var`. The `private` setters cause other unavoidable hibernate warnings now and so have been removed because the update method is exposed publicly and affords the same power. I see no compelling reason we need them private.

- `Alert.kt`, `final var deletedAt` field  is now a `var`, with the setter changed from `private` to `internal`, this avoids the warnings yet does trust the developer to not touch this. Code reviews will pick up on incorrectly accessing modifying this field anyway. We have to do this due to a new error that appears when removing `final`:  `PersonSummary.kt:24:5 Private setters for open properties are prohibited.`