### PR TITLE
CDPS-2061 Prevent duplicate active alerts from being created in DPS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/repository/AlertRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/repository/AlertRepository.kt
@@ -26,6 +26,9 @@ interface AlertRepository :
   @EntityGraph(value = "alert")
   fun findByPrisonNumberAndAlertCodeCode(prisonNumber: String, alertCode: String): Collection<Alert>
 
+  @Query(value = "select pg_advisory_xact_lock(hashtext(:prisonNumber), hashtext(:alertCode))", nativeQuery = true)
+  fun lockActiveAlertCreation(prisonNumber: String, alertCode: String)
+
   @Query(value = "select * from alert a where a.id = :alertUuid", nativeQuery = true)
   fun findByAlertUuidIncludingSoftDelete(alertUuid: UUID): Alert?
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/service/AlertService.kt
@@ -48,6 +48,7 @@ class AlertService(
 
     if (notNomis) {
       check(request.dateRangeIsValid()) { "Active from must be before active to" }
+      alertRepository.lockActiveAlertCreation(prisoner.prisonerNumber, request.alertCode)
       checkForExistingActiveAlert(prisoner.prisonerNumber, request.alertCode)
     }
     if (!alertCode.canBeAdministeredByUser(context.username)) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/CreateAlertIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/CreateAlertIntTest.kt
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.queryForObject
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.common.toZoneDateTime
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.Alert
@@ -532,7 +533,6 @@ class CreateAlertIntTest : IntegrationTestBase() {
 
   @Test
   fun `concurrent dps requests do not create duplicate active alerts`() {
-    val prisonNumber = givenPrisoner()
     val alertCode = givenAlertCode()
     val request = createAlertRequest(alertCode.code)
     val executor = Executors.newFixedThreadPool(2)
@@ -542,8 +542,8 @@ class CreateAlertIntTest : IntegrationTestBase() {
     try {
       val blocker = executor.submit {
         transactionTemplate.executeWithoutResult {
-          alertRepository.lockActiveAlertCreation(prisonNumber, alertCode.code)
-          givenAlert(alert(prisonNumber, alertCode))
+          alertRepository.lockActiveAlertCreation(PRISON_NUMBER, alertCode.code)
+          givenAlert(alert(PRISON_NUMBER, alertCode))
           alertRepository.flush()
           blockerReady.countDown()
           check(releaseBlocker.await(10, SECONDS))
@@ -552,12 +552,11 @@ class CreateAlertIntTest : IntegrationTestBase() {
       check(blockerReady.await(10, SECONDS))
 
       val response = executor.submit<ErrorResponse> {
-        webTestClient.createAlertResponseSpec(prisonNumber, request).errorResponse(CONFLICT)
+        webTestClient.createAlertResponseSpec(PRISON_NUMBER, request).errorResponse(CONFLICT)
       }
       await atMost ofSeconds(10) untilCallTo {
-        jdbcTemplate.queryForObject(
+        jdbcTemplate.queryForObject<Long>(
           "select count(*) from pg_locks where locktype = 'advisory' and not granted",
-          Long::class.java,
         )
       } matches { it != null && it > 0 }
 
@@ -569,7 +568,7 @@ class CreateAlertIntTest : IntegrationTestBase() {
         assertThat(userMessage).isEqualTo("Duplicate failure: Alert already exists")
         assertThat(developerMessage).isEqualTo("Alert already exists with identifier ${request.alertCode}")
       }
-      assertThat(alertRepository.findByPrisonNumberAndAlertCodeCode(prisonNumber, alertCode.code).filter { it.isActive() }).hasSize(1)
+      assertThat(alertRepository.findByPrisonNumberAndAlertCodeCode(PRISON_NUMBER, alertCode.code).filter { it.isActive() }).hasSize(1)
     } finally {
       releaseBlocker.countDown()
       executor.shutdownNow()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/CreateAlertIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/CreateAlertIntTest.kt
@@ -2,16 +2,19 @@ package uk.gov.justice.digital.hmpps.hmppsalertsapi.resource
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
+import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.common.toZoneDateTime
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.entity.Alert
@@ -41,12 +44,19 @@ import uk.gov.justice.digital.hmpps.hmppsalertsapi.utils.ALERT_CODE_INACTIVE_COV
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.utils.ALERT_CODE_VICTIM
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.utils.EntityGenerator.alertCode
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.utils.RequestGenerator.alertCodeSummary
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+import java.time.Duration.ofSeconds
 import java.time.LocalDate.now
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.SECONDS
 import uk.gov.justice.digital.hmpps.hmppsalertsapi.model.Alert as AlertModel
 
 class CreateAlertIntTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var jdbcTemplate: JdbcTemplate
 
   @Test
   fun `401 unauthorised`() {
@@ -517,6 +527,52 @@ class CreateAlertIntTest : IntegrationTestBase() {
       assertThat(userMessage).isEqualTo("Duplicate failure: Alert already exists")
       assertThat(developerMessage).isEqualTo("Alert already exists with identifier ${request.alertCode}")
       assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `concurrent dps requests do not create duplicate active alerts`() {
+    val prisonNumber = givenPrisoner()
+    val alertCode = givenAlertCode()
+    val request = createAlertRequest(alertCode.code)
+    val executor = Executors.newFixedThreadPool(2)
+    val blockerReady = CountDownLatch(1)
+    val releaseBlocker = CountDownLatch(1)
+
+    try {
+      val blocker = executor.submit {
+        transactionTemplate.executeWithoutResult {
+          alertRepository.lockActiveAlertCreation(prisonNumber, alertCode.code)
+          givenAlert(alert(prisonNumber, alertCode))
+          alertRepository.flush()
+          blockerReady.countDown()
+          check(releaseBlocker.await(10, SECONDS))
+        }
+      }
+      check(blockerReady.await(10, SECONDS))
+
+      val response = executor.submit<ErrorResponse> {
+        webTestClient.createAlertResponseSpec(prisonNumber, request).errorResponse(CONFLICT)
+      }
+      await atMost ofSeconds(10) untilCallTo {
+        jdbcTemplate.queryForObject(
+          "select count(*) from pg_locks where locktype = 'advisory' and not granted",
+          Long::class.java,
+        )
+      } matches { it != null && it > 0 }
+
+      releaseBlocker.countDown()
+      blocker.get(10, SECONDS)
+
+      with(response.get(10, SECONDS)) {
+        assertThat(status).isEqualTo(409)
+        assertThat(userMessage).isEqualTo("Duplicate failure: Alert already exists")
+        assertThat(developerMessage).isEqualTo("Alert already exists with identifier ${request.alertCode}")
+      }
+      assertThat(alertRepository.findByPrisonNumberAndAlertCodeCode(prisonNumber, alertCode.code).filter { it.isActive() }).hasSize(1)
+    } finally {
+      releaseBlocker.countDown()
+      executor.shutdownNow()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/StartBulkPlanIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsalertsapi/resource/StartBulkPlanIntTest.kt
@@ -212,6 +212,7 @@ class StartBulkPlanIntTest : IntegrationTestBase() {
     val prisonNumbers = people.map { it.prisonNumber }.toSet()
     val existingAlertsToExpire = alertRepository.findAllActiveByCode("XNR")
       .filter { it.prisonNumber !in prisonNumbers }
+    val affectedPrisonNumbers = prisonNumbers + existingAlertsToExpire.map { it.prisonNumber }
 
     val startTime = LocalDateTime.now()
     startPlanResponseSpec(plan.id).expectStatus().isAccepted
@@ -257,9 +258,10 @@ class StartBulkPlanIntTest : IntegrationTestBase() {
     }
 
     await atMost ofSeconds(30) withPollDelay ofSeconds(5) untilCallTo { hmppsEventsQueue.countAllMessagesOnQueue() } matches {
-      it == 45
+      it != null && it >= 45
     }
-    val messages = hmppsEventsQueue.receiveAllMessages()
+    val messages = hmppsEventsQueue.receiveAllMessages().filter { it.personReference.findNomsNumber() in affectedPrisonNumbers }
+    assertThat(messages).hasSize(45)
     val created = messages.filter { it.eventType == DomainEventType.ALERT_CREATED.eventType }
     assertThat(created).hasSize(saved.createdCount!!)
     val updated = messages.filter { it.eventType == DomainEventType.ALERT_UPDATED.eventType }


### PR DESCRIPTION
Following from [CDPS-1930](https://dsdmoj.atlassian.net/browse/CDPS-1930), which investigated why duplicate active alerts were sometimes being created for a prisoner if done via DPS, this PR solves the issue as unobtrusively as possible.

When a user creates an alert in the front-end profile, it sends a `POST` request to this API. However, due to differences in retry logic between each service, the front-end can time out after five seconds while this API is still retrying downstream calls. A repeated request can therefore overlap the original. Previously, both requests could pass the active-alert check before either transaction committed, resulting in two alerts and two sets of domain events. NOMIS accepted the first event, rejected the duplicate following the active-check, and sent it to its dead-letter queue.

Several solutions were previously posited by myself: upon further investigation, none of these are suitable:
- `Increasing the frontend timeout` would reduce the likelihood of overlap, but would remain coupled to back-end retry timings and would not prevent multiple-submits or other concurrent callers (both relatively common in establishments with patchy internet connections, or when several users access the same profile at once)
- `Disabling retries at API level` would reduce resilience to transient downstream failures, but without actually removing the underlying race condition (and with the added downside of forcing the front-end to make brand new requests each time, making it slower)
- `Introducing a global database uniqueness constraint` would offer broader enforcement, but is both intrusive (requiring a DB migration) and risks affecting how the NOMIS DB deals with domain events, bulk processing, reconciliation, &c.

Instead, I have opted to `implement a transaction-scoped advisory lock` on DPS create requests only. In this implementation, the first of two requests for the same prisoner and alert code creates and commits the alert; the second then sees it and receives a 409 Conflict. If the first request rolls back, the second remains able to create the alert. Only a successful request persists audit data and publishes events, so NOMIS receives one alert-creation event instead of two, preventing the reported duplicate from reaching NOMIS and entering its dead-letter queue.

This is the most targeted solution for the reported DPS path. It leaves retries, API contracts, NOMIS ingestion, resync and bulk-alert behaviour unchanged, while serialising competing creates for the same prisoner and alert code. The frontend may still observe a timeout followed by a 409, but only one alert and one corresponding set of creation events will be persisted.

[CDPS-1930]: https://dsdmoj.atlassian.net/browse/CDPS-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ